### PR TITLE
Swap the Descriptions

### DIFF
--- a/Common/src/main/resources/assets/bovinesandbuttercups/lang/en_us.json
+++ b/Common/src/main/resources/assets/bovinesandbuttercups/lang/en_us.json
@@ -54,7 +54,7 @@
   "resourcePack.bovinesandbuttercups.mojang.name": "Mojang Textures",
   "resourcePack.bovinesandbuttercups.mojang.description": "Returns mooblooms to their official textures.",
   "resourcePack.bovinesandbuttercups.noGrass.name": "No Grass Back",
-  "resourcePack.bovinesandbuttercups.noGrass.description": "Sets all baby moobloom buds to flowers.",
+  "resourcePack.bovinesandbuttercups.noGrass.description": "Removes grass and mycelium from cow backs.",
   "resourcePack.bovinesandbuttercups.noBuds.name": "No Buds",
-  "resourcePack.bovinesandbuttercups.noBuds.description": "Removes grass and mycelium from cow backs."
+  "resourcePack.bovinesandbuttercups.noBuds.description": "Sets all baby moobloom buds to flowers."
 }


### PR DESCRIPTION
No Grass Back and No Buds Resourcepack descriptions were reversed: -switched them back to correctness(very cool😎)